### PR TITLE
chore: add redirect for idm-core

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -82,14 +82,16 @@ export default defineConfig({
 				: "/keystatic",
 			status: 307,
 		},
-		'/idm-core': {
-      status: 302, 
-      destination: 'https://raw.githubusercontent.com/InTaVia/idm-rdf/refs/heads/main/idm-OWL/intavia_idm1.1.ttl',
-    },
-    '/idm-core/*': {
-      status: 302,
-      destination: 'https://raw.githubusercontent.com/InTaVia/idm-rdf/refs/heads/main/idm-OWL/intavia_idm1.1.ttl',
-    },
+		"/idm-core": {
+			status: 302,
+			destination:
+				"https://raw.githubusercontent.com/InTaVia/idm-rdf/refs/heads/main/idm-OWL/intavia_idm1.1.ttl",
+		},
+		"/idm-core/*": {
+			status: 302,
+			destination:
+				"https://raw.githubusercontent.com/InTaVia/idm-rdf/refs/heads/main/idm-OWL/intavia_idm1.1.ttl",
+		},
 	},
 	scopedStyleStrategy: "where",
 	security: {

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -82,6 +82,14 @@ export default defineConfig({
 				: "/keystatic",
 			status: 307,
 		},
+		'/idm-core': {
+      status: 302, 
+      destination: 'https://raw.githubusercontent.com/InTaVia/idm-rdf/refs/heads/main/idm-OWL/intavia_idm1.1.ttl',
+    },
+    '/idm-core/*': {
+      status: 302,
+      destination: 'https://raw.githubusercontent.com/InTaVia/idm-rdf/refs/heads/main/idm-OWL/intavia_idm1.1.ttl',
+    },
 	},
 	scopedStyleStrategy: "where",
 	security: {


### PR DESCRIPTION
adds a redirect, so idm-core classes can resolve to the class definition in the ttl