### PR TITLE
feat: add catch-all route to redirect specific paths to external site

### DIFF
--- a/src/pages/[...rest].astro
+++ b/src/pages/[...rest].astro
@@ -1,0 +1,16 @@
+---
+export const prerender = false;
+
+const path = Astro.url.pathname;
+const allowedPrefixes = ["/test", "/bs", "/apis"];
+
+const shouldRedirect = allowedPrefixes.some((prefix) => path.startsWith(prefix));
+
+if (shouldRedirect) {
+	const requestedUrl = Astro.url.toString();
+	return Astro.redirect(`https://second_website?url=${encodeURIComponent(requestedUrl)}`, 302);
+}
+
+// For non-matching paths, return 404
+return new Response("Not Found", { status: 404 });
+---


### PR DESCRIPTION
Add [...rest].astro catch-all route that:
- Redirects paths with /test, /bs, or /apis etc. prefixes
  to triplestore
- Returns 404 for all other paths
- Uses 302 temporary redirect